### PR TITLE
Improved configuration

### DIFF
--- a/src/info.plist
+++ b/src/info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>bundleid</key>
-	<string>net.deanishe.alfred-fakeum</string>
+	<string>giovanni.alfred-fakeum</string>
 	<key>category</key>
 	<string>Productivity</string>
 	<key>connections</key>
@@ -1167,7 +1167,7 @@ There is also a **Snippet Trigger** (`xxfake` by default) to insert fake data di
 			<key>description</key>
 			<string></string>
 			<key>label</key>
-			<string>LIPSUM_SENTENCES</string>
+			<string>Lipsum Sentences</string>
 			<key>type</key>
 			<string>textfield</string>
 			<key>variable</key>
@@ -1177,28 +1177,24 @@ There is also a **Snippet Trigger** (`xxfake` by default) to insert fake data di
 			<key>config</key>
 			<dict>
 				<key>default</key>
-				<string>1</string>
-				<key>placeholder</key>
-				<string></string>
+				<true/>
 				<key>required</key>
 				<false/>
-				<key>trim</key>
-				<true/>
+				<key>text</key>
+				<string>Show notifications</string>
 			</dict>
 			<key>description</key>
 			<string></string>
 			<key>label</key>
-			<string>SHOW_NOTIFICATIONS</string>
+			<string>Notifications</string>
 			<key>type</key>
-			<string>textfield</string>
+			<string>checkbox</string>
 			<key>variable</key>
 			<string>SHOW_NOTIFICATIONS</string>
 		</dict>
 	</array>
-	<key>variablesdontexport</key>
-	<array/>
 	<key>version</key>
-	<string>2.3.1</string>
+	<string>2.3.2</string>
 	<key>webaddress</key>
 	<string>https://github.com/giovannicoppola/alfred-fakeum</string>
 </dict>

--- a/src/info.plist
+++ b/src/info.plist
@@ -302,7 +302,7 @@
 		</array>
 	</dict>
 	<key>createdby</key>
-	<string>Dean Jackson</string>
+	<string>Giovanni Coppola</string>
 	<key>description</key>
 	<string>Generate Fake Data</string>
 	<key>disabled</key>


### PR DESCRIPTION
Before / After:

<img width="333" src="https://github.com/giovannicoppola/alfred-fakeum/assets/1699443/8876051f-4e28-432c-82f5-9e59b1665fe9">
<img width="333" alt="image" src="https://github.com/giovannicoppola/alfred-fakeum/assets/1699443/d5c95a6c-bf76-498b-a701-91e52bc33b01">

Also, updated the bundle ID because this is *your* version of the workflow. If Dean were to ever submit his, he’d have the bundle ID that is currently there. Same thing for the author, it would be might confusing to see one author in the Gallery and have another in the workflow’s list.