### PR TITLE
fix: ModuleNotFoundError for six.moves import

### DIFF
--- a/src/libs/dateutil/tz/tz.py
+++ b/src/libs/dateutil/tz/tz.py
@@ -17,8 +17,7 @@ import weakref
 from collections import OrderedDict
 
 import six
-from six import string_types
-from six.moves import _thread
+from six import moves, string_types
 from ._common import tzname_in_python2, _tzinfo
 from ._common import tzrangebase, enfold
 from ._common import _validate_fromutc_inputs
@@ -1166,7 +1165,7 @@ class _tzicalvtz(_tzinfo):
         self._comps = comps
         self._cachedate = []
         self._cachecomp = []
-        self._cache_lock = _thread.allocate_lock()
+        self._cache_lock = moves._thread.allocate_lock()
 
     def _find_comp(self, dt):
         if len(self._comps) == 1:
@@ -1541,7 +1540,7 @@ def __get_gettz():
             self.__instances = weakref.WeakValueDictionary()
             self.__strong_cache_size = 8
             self.__strong_cache = OrderedDict()
-            self._cache_lock = _thread.allocate_lock()
+            self._cache_lock = moves._thread.allocate_lock()
 
         def __call__(self, name=None):
             with self._cache_lock:


### PR DESCRIPTION
# Note

Tested with OSX built-in Python, Pyenv Python & Homebrew Python. This will fix all the installation.

# Environment

OSX 15.2 (24C101)
Python 3.13.1
Alfred 5.5.1 [2273]

# Debug log

```
07:07:54 workflow.py:2093 DEBUG    ---------- Fakeum (2.3.1) ----------
07:07:54 fakeum.py:228 DEBUG    query=''
07:07:54 workflow.py:2114 ERROR    No module named 'six.moves'
Traceback (most recent call last):
  File "/alfred_path/Alfred.alfredpreferences/workflows/user.workflow.B8849AF1-03E8-4451-A4A4-FD42B92C9B12/workflow/workflow.py", line 2107, in run
    func(self)
    ~~~~^^^^^^
  File "/alfred_path/Alfred.alfredpreferences/workflows/user.workflow.B8849AF1-03E8-4451-A4A4-FD42B92C9B12/fakeum.py", line 258, in main
    fake_data = get_fake_data()
  File "/alfred_path/Alfred.alfredpreferences/workflows/user.workflow.B8849AF1-03E8-4451-A4A4-FD42B92C9B12/fakeum.py", line 197, in get_fake_data
    names = [n for n in names if supported_type(n)]
                                 ~~~~~~~~~~~~~~^^^
  File "/alfred_path/Alfred.alfredpreferences/workflows/user.workflow.B8849AF1-03E8-4451-A4A4-FD42B92C9B12/fakeum.py", line 182, in supported_type
    for faker in all_fakers():
                 ~~~~~~~~~~^^
  File "/alfred_path/Alfred.alfredpreferences/workflows/user.workflow.B8849AF1-03E8-4451-A4A4-FD42B92C9B12/fakeum.py", line 132, in all_fakers
    from faker import Factory
  File "/alfred_path/Alfred.alfredpreferences/workflows/user.workflow.B8849AF1-03E8-4451-A4A4-FD42B92C9B12/libs/faker/__init__.py", line 2, in <module>
    from faker.factory import Factory  # noqa F401
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/alfred_path/Alfred.alfredpreferences/workflows/user.workflow.B8849AF1-03E8-4451-A4A4-FD42B92C9B12/libs/faker/factory.py", line 13, in <module>
    from faker.config import DEFAULT_LOCALE, PROVIDERS, AVAILABLE_LOCALES
  File "/alfred_path/Alfred.alfredpreferences/workflows/user.workflow.B8849AF1-03E8-4451-A4A4-FD42B92C9B12/libs/faker/config.py", line 14, in <module>
    AVAILABLE_LOCALES = find_available_locales(PROVIDERS)
  File "/alfred_path/Alfred.alfredpreferences/workflows/user.workflow.B8849AF1-03E8-4451-A4A4-FD42B92C9B12/libs/faker/utils/loading.py", line 44, in find_available_locales
    provider_module = import_module(provider_path)
  File "/usr/local/Cellar/python@3.13/3.13.1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/importlib/__init__.py", line 88, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/alfred_path/Alfred.alfredpreferences/workflows/user.workflow.B8849AF1-03E8-4451-A4A4-FD42B92C9B12/libs/faker/providers/address/__init__.py", line 5, in <module>
    from .. import date_time
  File "/alfred_path/Alfred.alfredpreferences/workflows/user.workflow.B8849AF1-03E8-4451-A4A4-FD42B92C9B12/libs/faker/providers/date_time/__init__.py", line 12, in <module>
    from dateutil.tz import tzlocal, tzutc
  File "/alfred_path/Alfred.alfredpreferences/workflows/user.workflow.B8849AF1-03E8-4451-A4A4-FD42B92C9B12/libs/dateutil/tz/__init__.py", line 2, in <module>
    from .tz import *
  File "/alfred_path/Alfred.alfredpreferences/workflows/user.workflow.B8849AF1-03E8-4451-A4A4-FD42B92C9B12/libs/dateutil/tz/tz.py", line 21, in <module>
    from six.moves import _thread
ModuleNotFoundError: No module named 'six.moves'
07:07:54 workflow.py:2116 INFO     for assistance, see: https://github.com/giovannicoppola/alfred-fakeum/issues
07:07:54 workflow.py:2136 DEBUG    ---------- finished in 0.036s ----------
```
